### PR TITLE
fixit neverallow

### DIFF
--- a/sepolicy/vendor/cameraserver.te
+++ b/sepolicy/vendor/cameraserver.te
@@ -1,4 +1,4 @@
-get_prop(cameraserver, vendor_default_prop)
+allow cameraserver vendor_camera_prop:file { read getattr map open };
 
 allow cameraserver sysfs_leds:dir r_dir_perms;
 allow cameraserver sysfs_torch:file rw_file_perms;


### PR DESCRIPTION
FAILED: out/soong/.intermediates/system/sepolicy/precompiled_sepolicy/android_common/ziyi/precompiled_sepolicy out/host/linux-x86/bin/secilc -m -M true -G -c 30 out/soong/.intermediates/system/sepolicy/plat_sepolicy.cil/android_common/plat_sepolicy.cil out/soong/.intermediates/system/s epolicy/plat_pub_versioned.cil/android_common/ziyi/plat_pub_versioned.cil out/soong/.intermediates/system/sepolicy/system_ext_sepolicy.cil/android_common/ziyi/system_ext_sepol icy.cil out/soong/.intermediates/system/sepolicy/product_sepolicy.cil/android_common/ziyi/product_sepolicy.cil out/soong/.intermediates/system/sepolicy/vendor_sepolicy.cil/and roid_common/ziyi/vendor_sepolicy.cil out/soong/.intermediates/system/sepolicy/odm_sepolicy.cil/android_common/ziyi/odm_sepolicy.cil out/soong/.intermediates/system/sepolicy/pl at_mapping_file/android_common/202404.cil out/soong/.intermediates/system/sepolicy/system_ext_mapping_file/android_common/ziyi/202404.cil out/soong/.intermediates/system/sepol icy/product_mapping_file/android_common/ziyi/202404.cil -o out/soong/.intermediates/system/sepolicy/precompiled_sepolicy/android_common/ziyi/precompiled_sepolicy_policy -f /de v/null && cp -f out/soong/.intermediates/system/sepolicy/precompiled_sepolicy/android_common/ziyi/precompiled_sepolicy_policy out/soong/.intermediates/system/sepolicy/precompi led_sepolicy/android_common/ziyi/precompiled_sepolicy && rm -f out/soong/.intermediates/system/sepolicy/precompiled_sepolicy/android_common/ziyi/precompiled_sepolicy_policy #  hash of input list: d08a75b21e40602c3fceaf717d876d5af235f3b5e3f34964c63c9d86867b82ed neverallow check failed at out/soong/.intermediates/system/sepolicy/plat_pub_versioned.cil/android_common/ziyi/plat_pub_versioned.cil:6025
  (neverallow base_typeattr_225_202404 vendor_default_prop_202404 (file (ioctl read write create setattr lock relabelfrom append unlink link rename open watch watch_mount watc
h_sb watch_with_perm watch_reads)))
    <root>
    allow at out/soong/.intermediates/system/sepolicy/vendor_sepolicy.cil/android_common/ziyi/vendor_sepolicy.cil:10895
      (allow cameraserver_202404 vendor_default_prop_202404 (file (read getattr map open)))

neverallow check failed at out/soong/.intermediates/system/sepolicy/plat_sepolicy.cil/android_common/plat_sepolicy.cil:25896 from system/sepolicy/private/property.te:158
  (neverallow base_typeattr_225 base_typeattr_867 (file (ioctl read write create setattr lock relabelfrom append unlink link rename open watch watch_mount watch_sb watch_with_
perm watch_reads)))
    <root>
    allow at out/soong/.intermediates/system/sepolicy/vendor_sepolicy.cil/android_common/ziyi/vendor_sepolicy.cil:10895
      (allow cameraserver_202404 vendor_default_prop_202404 (file (read getattr map open)))

neverallow check failed at out/soong/.intermediates/system/sepolicy/plat_sepolicy.cil/android_common/plat_sepolicy.cil:8627 from system/sepolicy/public/property.te:358
  (neverallow base_typeattr_225 vendor_default_prop (file (ioctl read write create setattr lock relabelfrom append unlink link rename open watch watch_mount watch_sb watch_wit
h_perm watch_reads)))
    <root>
    allow at out/soong/.intermediates/system/sepolicy/vendor_sepolicy.cil/android_common/ziyi/vendor_sepolicy.cil:10895
      (allow cameraserver_202404 vendor_default_prop_202404 (file (read getattr map open)))